### PR TITLE
Remove devices by ID if possible + misc fixes and cleanup

### DIFF
--- a/qemu_usb_device_manager/client.py
+++ b/qemu_usb_device_manager/client.py
@@ -105,7 +105,7 @@ class Client(object):
 		# If monitor_host starts with a colon, we should guess which IP to use
 		# when it's not, Monitor IP:Port is probably specified by user
 		if monitor_host[0] != ":":
-			self.monitor = Monitor(host)
+			self.monitor = Monitor(monitor_host)
 			return True
 
 		# Did user define their own monitor host?
@@ -200,7 +200,7 @@ class Client(object):
 
 	def run_command(self, text):
 		"""
-		Run command for monitor 
+		Run command for monitor
 		
 		Args:
 			text (str): Command

--- a/qemu_usb_device_manager/client.py
+++ b/qemu_usb_device_manager/client.py
@@ -24,7 +24,7 @@ class Client(object):
 
 	def __init__(self, machine_name, config_filepath, log_filepath=None):
 		"""
-		Load configuration from yaml/json file.
+		Load configuration from yaml file.
 		
 		Args:
 			config_filepath (str): Configuration file path
@@ -47,7 +47,7 @@ class Client(object):
 		"""
 		try:
 			with open(self.config_filepath) as f:
-				self.config = yaml.load(f)
+				self.config = yaml.load(f, Loader=yaml.FullLoader)
 		except Exception as exc:
 			logging.exception(exc)
 			return False
@@ -317,7 +317,7 @@ class Client(object):
 	def command_update(self, args):
 		"""
 		Download url set in 'configuration-url' and attempt to parse with YAML.
-		If the new config is valid JSON/YAML then replace current config.
+		If the new config is valid YAML then replace current config.
 		
 		Args:
 			args (list): List arguments

--- a/qemu_usb_device_manager/main.py
+++ b/qemu_usb_device_manager/main.py
@@ -17,7 +17,7 @@ def main():
 	parser = ArgumentParser(description="Limited QEMU Monitor Wrapper for USB management")
 	parser.add_argument("--name", "--set", "-n", "-s", help="Name of virtual machine")
 	parser.add_argument("--command", "-c", help="Command", nargs="*")
-	parser.add_argument("--config", "--conf", help="YAML/JSON config file location", nargs="?")
+	parser.add_argument("--config", "--conf", help="YAML config file location", nargs="?")
 	parser.add_argument("--log", help="Log file location", nargs="?")
 	args = parser.parse_args()
 
@@ -28,7 +28,7 @@ def main():
 		config_filepath = args.config
 
 	else:
-		extensions = (".yml", ".yaml", ".json")
+		extensions = (".yml", ".yaml")
 
 		# Attempt to find local config
 		config_filepath = find_file(

--- a/qemu_usb_device_manager/monitor.py
+++ b/qemu_usb_device_manager/monitor.py
@@ -102,7 +102,6 @@ class Monitor(object):
 		Args:
 			device (str): Device ID
 		"""
-		data = self.usb_devices_more()
 		result = True
 
 		# Single device
@@ -132,11 +131,9 @@ class Monitor(object):
 		Args:
 			device (str): Device ID
 		"""
-		data = self.usb_devices_more()
 
 		# Single device
 		if type(device) is str:
-			#self.__write("usb_del %s" % self.id_to_device(device))
 			args = self.device_ids(device)[2]
 			self.__write("device_del " + args)
 
@@ -165,41 +162,17 @@ class Monitor(object):
 		return (vendor_id, product_id, cosmetic_id)
 
 
-
-	def id_to_device(self, value, data=None):
-		"""
-		Find device id (0.0) from vendor and product id by comparing host device
-		names to connected virtual machine device names.
-		
-		Args:
-			value (str): Vendor:Product ID
-			data (bool, optional): Prefetched data of .host_usb_devices_more()
-
-		Returns:
-			Device if found, otherwise it returns original value
-		"""
-		if not data:
-			data = self.usb_devices_more()
-
-		if value.startswith("host:"):
-			value = value[5:]
-
-		return next((d["device"] for d in data if d["id"] == value), value)
-		
-
-	def id_is_connected(self, value, data=None):
+	def id_is_connected(self, value):
 		"""
 		Test if device is connected by vendor and product id.
 		
 		Args:
 			value (str): Vendor:Product ID
-			data (bool, optional): Prefetched data of .host_usb_devices_more()
 
 		Returns:
 			bool, connected or not
 		"""
-		if not data:
-			data = self.usb_devices_more()
+		data = self.usb_devices_more()
 
 		if value.startswith("host:"):
 			value = value[5:]


### PR DESCRIPTION
* Fixed an undefined variable error when trying to connect using `hostname:port` or `ip:port` monitor string
* Updated `yaml.load` call to avoid deprecation warning
* Cleaned up remnants of JSON config support
* Removed unused prefetch code for `usb_devices_more`
* Removed unused `id_to_device` function
* Added logic to find user-supplied device ID on the host (eg. `-device usb-host,vendorid=0xdead,productid=0xbeef,id=<userid>`)
* Prefer the new ID when calling the monitor to remove devices, as that seems to be the only syntax accepted by monitors on 5.x.x qemu versions

If you feel like any of the changes in unnecessary, I can make a new PR with a subset of these.